### PR TITLE
Define reduce() in Python 3

### DIFF
--- a/src/py2.x/dl/fc.py
+++ b/src/py2.x/dl/fc.py
@@ -7,6 +7,11 @@ import random
 import numpy as np
 from activators import SigmoidActivator, IdentityActivator
 
+try:
+    reduce         # Python 2
+except NameError:  # Python 3
+    from functools import reduce
+
 
 # 全连接层实现类
 class FullConnectedLayer(object):

--- a/src/py2.x/dl/rnn.py
+++ b/src/py2.x/dl/rnn.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-
 from __future__ import print_function
 import numpy as np
 from cnn import element_wise_op
 from activators import ReluActivator, IdentityActivator
+
+try:
+    reduce         # Python 2
+except NameError:  # Python 3
+    from functools import reduce
 
 
 class RecurrentLayer(object):


### PR DESCRIPTION
In Python 3 __reduce()__ moved from being a builtin to being in the __functools__ module.
* https://docs.python.org/3.0/library/functools.html#functools.reduce