### PR TITLE
RandomSelectNegativeSample() --> RandSelectNegativeSamples()

### DIFF
--- a/src/py3.x/16.RecommenderSystems/test_lfm.py
+++ b/src/py3.x/16.RecommenderSystems/test_lfm.py
@@ -2,7 +2,7 @@ import random
 
 
 # 负样本采样过程
-def RandomSelectNegativeSample(self, items):
+def RandSelectNegativeSamples(self, items):
     ret = {key: 1 for key in items}
     n = 0
     for i in range(0, len(items) * 3):


### PR DESCRIPTION
The function is defined as singular on line 5 but it returns multiple samples and is called as a plural on line 23.  This PR suggest using the plural form in both places.  Discovered using the tests that were suppressed in https://github.com/apachecn/AiLearning/commit/4e129cdf43e519fb05a6b0c7cb73ef1830f2a11b#commitcomment-33663962