### PR TITLE
Fix typo and remove not used style tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ ailearning <port>
 > 目录结构:
 
 * [安装指南](docs/TensorFlow2.x/安装指南.md)
-* [Kears 快速入门](docs/TensorFlow2.x/Keras快速入门.md)
+* [Keras 快速入门](docs/TensorFlow2.x/Keras快速入门.md)
 * [实战项目 1 电影情感分类](docs/TensorFlow2.x/实战项目_1_电影情感分类.md)
 * [实战项目 2 汽车燃油效率](docs/TensorFlow2.x/实战项目_2_汽车燃油效率.md)
 * [实战项目 3 优化 过拟合和欠拟合](docs/TensorFlow2.x/实战项目_3_优化_过拟合和欠拟合.md)

--- a/docs/TensorFlow2.x/Keras快速入门.md
+++ b/docs/TensorFlow2.x/Keras快速入门.md
@@ -28,7 +28,7 @@ model.evaluate(dataset)
 
 ## Keras Sequential 顺序模型
 
-顺序模型是多个网络层的线性堆叠，目前支持2中方式
+顺序模型是多个网络层的线性堆叠，目前支持2种方式
 
 ### 构造模型
 

--- a/docs/TensorFlow2.x/实战项目_2_汽车燃油效率.md
+++ b/docs/TensorFlow2.x/实战项目_2_汽车燃油效率.md
@@ -14,7 +14,7 @@ Note: 我们的 TensorFlow 社区翻译了这些文档。因为社区翻译是�
 
 ```python
 # 使用 seaborn 绘制矩阵图 (pairplot)
-!pip install seaborn
+$ pip install seaborn
 ```
 
     Requirement already satisfied: seaborn in /usr/local/lib/python3.6/dist-packages (0.9.0)
@@ -350,19 +350,6 @@ train_stats
 
 
 <div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">


### PR DESCRIPTION
1. Correct two typo
2. Style tag was sanitized by Github markdown for safety reasons, so the tag text was being rendered and may confuse readers.