### PR TITLE
docs: fix simple typo, puropses -> purposes

### DIFF
--- a/src/py2.x/ml/3.DecisionTree/decisionTreePlot.py
+++ b/src/py2.x/ml/3.DecisionTree/decisionTreePlot.py
@@ -118,7 +118,7 @@ def createPlot(inTree):
 # def createPlot():
 #     fig = plt.figure(1, facecolor='white')
 #     fig.clf()
-#     # ticks for demo puropses
+#     # ticks for demo purposes
 #     createPlot.ax1 = plt.subplot(111, frameon=False)
 #     plotNode('a decision node', (0.5, 0.1), (0.1, 0.5), decisionNode)
 #     plotNode('a leaf node', (0.8, 0.1), (0.3, 0.8), leafNode)

--- a/src/py3.x/ml/3.DecisionTree/decisionTreePlot.py
+++ b/src/py3.x/ml/3.DecisionTree/decisionTreePlot.py
@@ -117,7 +117,7 @@ def createPlot(inTree):
 # def createPlot():
 #     fig = plt.figure(1, facecolor='white')
 #     fig.clf()
-#     # ticks for demo puropses
+#     # ticks for demo purposes
 #     createPlot.ax1 = plt.subplot(111, frameon=False)
 #     plotNode('a decision node', (0.5, 0.1), (0.1, 0.5), decisionNode)
 #     plotNode('a leaf node', (0.8, 0.1), (0.3, 0.8), leafNode)


### PR DESCRIPTION
There is a small typo in src/py2.x/ml/3.DecisionTree/decisionTreePlot.py, src/py3.x/ml/3.DecisionTree/decisionTreePlot.py.

Should read `purposes` rather than `puropses`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md